### PR TITLE
Add playedata columns getter and fix load bug

### DIFF
--- a/src/main/java/fr/prisontycoon/commands/PlayerDataCommand.java
+++ b/src/main/java/fr/prisontycoon/commands/PlayerDataCommand.java
@@ -69,7 +69,7 @@ public class PlayerDataCommand implements CommandExecutor, TabCompleter {
             }
             case "load" -> {
                 if (column == null) {
-                    plugin.getPlayerDataManager().reloadPlayerData(targetId, true);
+                    plugin.getPlayerDataManager().reloadPlayerData(targetId);
                     sender.sendMessage("§aRechargé depuis la base: §e" + targetName);
                 } else {
                     boolean ok = loadSingleColumn(targetId, column);

--- a/src/main/java/fr/prisontycoon/commands/PlayerDataCommand.java
+++ b/src/main/java/fr/prisontycoon/commands/PlayerDataCommand.java
@@ -35,7 +35,12 @@ public class PlayerDataCommand implements CommandExecutor, TabCompleter {
 
         if (args.length < 2) {
             sender.sendMessage("§eUsage: /" + label + " <save|load|dump> <joueur> [colonne]");
-            sender.sendMessage("§7Colonnes supportées: profession_levels, profession_xp, talent_levels, kit_levels, profession_rewards");
+            try {
+                List<String> cols = plugin.getPlayerDataManager().getAllPlayerColumns();
+                if (!cols.isEmpty()) {
+                    sender.sendMessage("§7Colonnes: §f" + String.join(", ", cols));
+                }
+            } catch (Exception ignored) {}
             return true;
         }
 
@@ -64,7 +69,7 @@ public class PlayerDataCommand implements CommandExecutor, TabCompleter {
             }
             case "load" -> {
                 if (column == null) {
-                    plugin.getPlayerDataManager().reloadPlayerData(targetId);
+                    plugin.getPlayerDataManager().reloadPlayerData(targetId, true);
                     sender.sendMessage("§aRechargé depuis la base: §e" + targetName);
                 } else {
                     boolean ok = loadSingleColumn(targetId, column);
@@ -231,7 +236,7 @@ public class PlayerDataCommand implements CommandExecutor, TabCompleter {
             }
             StringUtil.copyPartialMatches(args[1], players, completions);
         } else if (args.length == 3 && (args[0].equalsIgnoreCase("save") || args[0].equalsIgnoreCase("load"))) {
-            List<String> columns = Arrays.asList("profession_levels", "profession_xp", "talent_levels", "kit_levels", "profession_rewards");
+            List<String> columns = plugin.getPlayerDataManager().getAllPlayerColumns();
             StringUtil.copyPartialMatches(args[2], columns, completions);
         }
 

--- a/src/main/java/fr/prisontycoon/managers/PlayerDataManager.java
+++ b/src/main/java/fr/prisontycoon/managers/PlayerDataManager.java
@@ -779,54 +779,20 @@ public class PlayerDataManager {
         } catch (SQLException e) {
             plugin.getPluginLogger().debug("Impossible de lister les colonnes via metadata: " + e.getMessage());
         }
-
-        if (columns.isEmpty()) {
-            // Fallback statique aligné avec createPlayersTable()
-            columns = Arrays.asList(
-                    "uuid", "name", "coins", "tokens", "experience", "beacons",
-                    "coins_via_pickaxe", "tokens_via_pickaxe", "experience_via_pickaxe",
-                    "active_profession", "last_profession_change", "enchantments",
-                    "auto_upgrade", "mobility_disabled", "pickaxe_cristals", "custom_permissions",
-                    "sanctions", "active_enchantments", "pickaxe_enchantment_book_levels",
-                    "profession_levels", "profession_xp", "talent_levels", "kit_levels",
-                    "profession_rewards", "chosen_prestige_columns", "chosen_special_rewards",
-                    "reputation", "boosts", "autominer_active_slot_1", "autominer_active_slot_2",
-                    "autominer_fuel_reserve", "autominer_current_world", "autominer_storage_level",
-                    "autominer_storage_items", "autominer_pending_coins", "autominer_pending_tokens",
-                    "autominer_pending_experience", "autominer_pending_beacons", "bank_savings_balance",
-                    "bank_safe_balance", "bank_level", "bank_total_deposits", "bank_last_interest",
-                    "bank_investments", "statistics_total_blocks_mined", "statistics_total_blocks_destroyed",
-                    "statistics_total_greed_triggers", "statistics_total_keys_obtained", "gang_id",
-                    "gang_invitation", "selected_outpost_skin", "unlocked_outpost_skins",
-                    "collected_heads", "claimed_head_rewards"
-            );
-        }
         return columns;
     }
 
     /**
      * NOUVELLE MÉTHODE : Force le rechargement d'un joueur depuis la BDD
-     * @param playerId Joueur ciblé
-     * @param discardUnsaved Si true, ignore et supprime les changements non sauvegardés au lieu de les persister
      */
-    public void reloadPlayerData(UUID playerId, boolean discardUnsaved) {
+    public void reloadPlayerData(UUID playerId) {
         if (playerId != null) {
-            if (!discardUnsaved && dirtyPlayers.contains(playerId)) {
-                savePlayerNow(playerId);
-            } else if (discardUnsaved) {
-                // Empêcher toute sauvegarde concurrente d'écrire l'ancien cache
-                dirtyPlayers.remove(playerId);
-            }
-
+            // Toujours ignorer les changements non sauvegardés
+            dirtyPlayers.remove(playerId);
             // Supprime du cache et recharge
             playerDataCache.remove(playerId);
             getPlayerData(playerId); // Force le rechargement
         }
-    }
-
-    // Compatibilité: surcharge sans paramètre, ne discard PAS par défaut
-    public void reloadPlayerData(UUID playerId) {
-        reloadPlayerData(playerId, false);
     }
 
     /**

--- a/src/main/java/fr/prisontycoon/managers/PlayerDataManager.java
+++ b/src/main/java/fr/prisontycoon/managers/PlayerDataManager.java
@@ -762,19 +762,71 @@ public class PlayerDataManager {
     }
 
     /**
-     * NOUVELLE MÉTHODE : Force le rechargement d'un joueur depuis la BDD
+     * Liste toutes les colonnes de la table players (lowercase). Fallback sur une liste statique si indisponible.
      */
-    public void reloadPlayerData(UUID playerId) {
+    public List<String> getAllPlayerColumns() {
+        List<String> columns = new ArrayList<>();
+        try (Connection conn = databaseManager.getConnection()) {
+            var meta = conn.getMetaData();
+            try (ResultSet rs = meta.getColumns(null, null, "players", null)) {
+                while (rs.next()) {
+                    String columnName = rs.getString("COLUMN_NAME");
+                    if (columnName != null) {
+                        columns.add(columnName.toLowerCase());
+                    }
+                }
+            }
+        } catch (SQLException e) {
+            plugin.getPluginLogger().debug("Impossible de lister les colonnes via metadata: " + e.getMessage());
+        }
+
+        if (columns.isEmpty()) {
+            // Fallback statique aligné avec createPlayersTable()
+            columns = Arrays.asList(
+                    "uuid", "name", "coins", "tokens", "experience", "beacons",
+                    "coins_via_pickaxe", "tokens_via_pickaxe", "experience_via_pickaxe",
+                    "active_profession", "last_profession_change", "enchantments",
+                    "auto_upgrade", "mobility_disabled", "pickaxe_cristals", "custom_permissions",
+                    "sanctions", "active_enchantments", "pickaxe_enchantment_book_levels",
+                    "profession_levels", "profession_xp", "talent_levels", "kit_levels",
+                    "profession_rewards", "chosen_prestige_columns", "chosen_special_rewards",
+                    "reputation", "boosts", "autominer_active_slot_1", "autominer_active_slot_2",
+                    "autominer_fuel_reserve", "autominer_current_world", "autominer_storage_level",
+                    "autominer_storage_items", "autominer_pending_coins", "autominer_pending_tokens",
+                    "autominer_pending_experience", "autominer_pending_beacons", "bank_savings_balance",
+                    "bank_safe_balance", "bank_level", "bank_total_deposits", "bank_last_interest",
+                    "bank_investments", "statistics_total_blocks_mined", "statistics_total_blocks_destroyed",
+                    "statistics_total_greed_triggers", "statistics_total_keys_obtained", "gang_id",
+                    "gang_invitation", "selected_outpost_skin", "unlocked_outpost_skins",
+                    "collected_heads", "claimed_head_rewards"
+            );
+        }
+        return columns;
+    }
+
+    /**
+     * NOUVELLE MÉTHODE : Force le rechargement d'un joueur depuis la BDD
+     * @param playerId Joueur ciblé
+     * @param discardUnsaved Si true, ignore et supprime les changements non sauvegardés au lieu de les persister
+     */
+    public void reloadPlayerData(UUID playerId, boolean discardUnsaved) {
         if (playerId != null) {
-            // Sauvegarde d'abord si le joueur est modifié
-            if (dirtyPlayers.contains(playerId)) {
+            if (!discardUnsaved && dirtyPlayers.contains(playerId)) {
                 savePlayerNow(playerId);
+            } else if (discardUnsaved) {
+                // Empêcher toute sauvegarde concurrente d'écrire l'ancien cache
+                dirtyPlayers.remove(playerId);
             }
 
             // Supprime du cache et recharge
             playerDataCache.remove(playerId);
             getPlayerData(playerId); // Force le rechargement
         }
+    }
+
+    // Compatibilité: surcharge sans paramètre, ne discard PAS par défaut
+    public void reloadPlayerData(UUID playerId) {
+        reloadPlayerData(playerId, false);
     }
 
     /**


### PR DESCRIPTION
Enhance `/playedata` command with dynamic column listing and fix `load` behavior to prevent overwriting manual DB changes.

The `/playedata load` command previously saved pending cache before reloading, which could overwrite manual database edits. This change ensures that `load` discards unsaved cache, forcing a fresh read from the database.

---
<a href="https://cursor.com/background-agent?bcId=bc-171c12d5-f1a6-4bea-b118-1a99b914421f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-171c12d5-f1a6-4bea-b118-1a99b914421f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

