### PR TITLE
Corriger et améliorer boostGUI et hovertext

### DIFF
--- a/src/main/java/fr/prisontycoon/gui/BoostGUI.java
+++ b/src/main/java/fr/prisontycoon/gui/BoostGUI.java
@@ -177,7 +177,7 @@ public class BoostGUI {
 
                     lore.add(category.getColor() + category.getEmoji() + " " + category.getDisplayName() +
                             "§7: §f×" + String.format("%.2f", details.getTotalMultiplier()) +
-                            " §7(+" + String.format("%.1f", details.getTotalBonus()) + "%)");
+                            " §7(" + String.format("%+.1f", details.getTotalBonus()) + "%)");
                 }
             }
         } else {
@@ -189,6 +189,10 @@ public class BoostGUI {
         lore.add("§7• Bonus des cristaux");
         lore.add("§7• Bonus des talents métiers");
         lore.add("§7• Bonus des talents prestige");
+        lore.add("§6• Bonus du gang (permanents)");
+        lore.add("§6• Boosts de gang (temporaires)");
+        lore.add("§9• Enchantements");
+        lore.add("§c• Surcharge de mine");
         lore.add("§b• Boosts temporaires");
         lore.add("");
         lore.add("§e▶ Cliquez pour les détails dans le chat");
@@ -361,30 +365,28 @@ public class BoostGUI {
                 var category = entry.getKey();
                 var details = entry.getValue();
 
-                String arrow = details.getTotalBonus() > 0 ? "§a↗" : "§7→";
+                String arrow = details.getTotalBonus() > 0 ? "§a↗" : (details.getTotalBonus() < 0 ? "§c↘" : "§7→");
 
                 Component hover = createBonusHoverComponent(category, details);
 
-                Component mainLine = Component.text(category.getColor() + "▶ " + category.getDisplayName())
+                String mainText = category.getColor() + "▶ " + category.getDisplayName();
+                Component mainLine = net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer.legacySection().deserialize(mainText)
                         .hoverEvent(HoverEvent.showText(hover))
                         .decoration(TextDecoration.ITALIC, false);
 
-                Component multLine = Component.text("  §7Multiplicateur: §f×" + String.format("%.3f", details.getTotalMultiplier()) +
-                                " " + arrow + " §f+" + String.format("%.1f", details.getTotalBonus()) + "%")
+                String multText = "  §7Multiplicateur: §f×" + String.format("%.3f", details.getTotalMultiplier()) +
+                                " " + arrow + " §f" + String.format("%+.1f", details.getTotalBonus()) + "%";
+                Component multLine = net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer.legacySection().deserialize(multText)
                         .hoverEvent(HoverEvent.showText(hover))
                         .decoration(TextDecoration.ITALIC, false);
 
-                player.sendMessage(net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer.legacySection().serialize(mainLine));
-                player.sendMessage(net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer.legacySection().serialize(multLine));
+                player.sendMessage(mainLine);
+                player.sendMessage(multLine);
             }
 
             player.sendMessage("");
 
-            Component infoHover = createGeneralInfoHoverComponent();
-            Component infoLine = Component.text("§7§lSources disponibles: §eCristaux §7| §dMétiers §7| §5Prestige §7| §bBoosts")
-                    .hoverEvent(HoverEvent.showText(infoHover))
-                    .decoration(TextDecoration.ITALIC, false);
-            player.sendMessage(net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer.legacySection().serialize(infoLine));
+
         }
 
         player.sendMessage("§7§m────────────────────────────────");
@@ -410,6 +412,10 @@ public class BoostGUI {
         if (details.getCristalBonus() > 0) sb.append("\n§e⚡ Cristaux§7: +").append(String.format("%.1f", details.getCristalBonus())).append("%");
         if (details.getProfessionBonus() > 0) sb.append("\n§d🔨 Talents Métiers§7: +").append(String.format("%.1f", details.getProfessionBonus())).append("%");
         if (details.getPrestigeBonus() > 0) sb.append("\n§5👑 Talents Prestige§7: +").append(String.format("%.1f", details.getPrestigeBonus())).append("%");
+        if (details.getGangBonus() > 0) sb.append("\n§6🏰 Gang (Perm.)§7: +").append(String.format("%.1f", details.getGangBonus())).append("%");
+        if (details.getTemporaryGangBoostBonus() > 0) sb.append("\n§6⚔ Boost de Gang§7: +").append(String.format("%.1f", details.getTemporaryGangBoostBonus())).append("%");
+        if (details.getEnchantmentBonus() > 0) sb.append("\n§9✨ Enchantements§7: +").append(String.format("%.2f", details.getEnchantmentBonus())).append("%");
+        if (details.getOverloadBonus() > 0) sb.append("\n§c🔥 Surcharge de Mine§7: +").append(String.format("%.1f", details.getOverloadBonus())).append("%");
         if (details.getTemporaryBoostBonus() > 0) sb.append("\n§b⚡ Boosts Temporaires§7: +").append(String.format("%.1f", details.getTemporaryBoostBonus())).append("%");
         if (!details.getDetailedSources().isEmpty()) {
             sb.append("\n\n§8Détails:");
@@ -417,7 +423,7 @@ public class BoostGUI {
                 sb.append("\n§8• ").append(source.getKey()).append(": +").append(String.format("%.1f", source.getValue())).append("%");
             }
         }
-        sb.append("\n\n§8Total: +").append(String.format("%.1f", details.getTotalBonus())).append("%");
+        sb.append("\n\n§8Total: ").append(String.format("%+.1f", details.getTotalBonus())).append("%");
         return net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer.legacySection().deserialize(sb.toString()).decoration(TextDecoration.ITALIC, false);
     }
 

--- a/src/main/java/fr/prisontycoon/managers/GlobalBonusManager.java
+++ b/src/main/java/fr/prisontycoon/managers/GlobalBonusManager.java
@@ -130,7 +130,7 @@ public class GlobalBonusManager {
 
         for (BonusCategory category : BonusCategory.values()) {
             BonusSourceDetails details = getBonusSourcesDetails(player, category);
-            if (details.getTotalBonus() > 0) {
+            if (details.getTotalBonus() != 0.0) {
                 bonuses.put(category, details);
             }
         }


### PR DESCRIPTION
Enhance BoostGUI to display all non-zero bonuses with full source details and fix chat hover functionality.

The original implementation only showed positive bonuses and had limited source details, and the chat messages were sent as legacy strings, preventing proper hover events. This PR addresses these issues by including negative bonuses, expanding the list of displayed sources, and sending Adventure Components directly for chat messages.

---
<a href="https://cursor.com/background-agent?bcId=bc-414b23d4-eb1c-4347-b743-c765c67df0a0">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-414b23d4-eb1c-4347-b743-c765c67df0a0">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

